### PR TITLE
DEP Use silverstripe account

### DIFF
--- a/Apache/Solr/Document.php
+++ b/Apache/Solr/Document.php
@@ -298,6 +298,7 @@ class Apache_Solr_Document implements IteratorAggregate
 	 * }
 	 * </code>
 	 */
+	#[\ReturnTypeWillChange]
 	public function getIterator()
 	{
 		$arrayObject = new ArrayObject($this->_fields);

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "ptcinc/solr-php-client",
+	"name": "silverstripe/solr-php-client",
 	"description": "A purely PHP library for indexing and searching documents against an Apache Solr installation",
 	"keywords": ["php", "solr", "client"],
 	"license": "BSD-3-Clause",
@@ -9,6 +9,9 @@
 			"homepage": "https://github.com/djimenez"
 		}
 	],
+	"replace": {
+		"ptcinc/solr-php-client": "^1.0"
+	},
 	"autoload": {
 		"psr-0": {
 			"Apache_Solr_": ""


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10250

Preferred over copying module to a thirdparty folder to a [third party](https://github.com/silverstripe/silverstripe-fulltextsearch/pull/320)

Also includes adding method attribute for PHP 8.1 compatibility

Copying approach which was take taken for [sminnee/phpunit](https://github.com/sminnee/phpunit/blob/5.7/composer.json)

Need to ensure that this module show up in packagist https://packagist.org/silverstripe/solr-php-client
