### PR TITLE
PHP 8.1 deprecation notice prevention

### DIFF
--- a/Apache/Solr/Service.php
+++ b/Apache/Solr/Service.php
@@ -816,7 +816,7 @@ class Apache_Solr_Service
 		foreach ($document as $key => $value)
 		{
 			$fieldBoost = $document->getFieldBoost($key);
-			$key = htmlspecialchars($key, ENT_QUOTES, 'UTF-8');
+			$key = htmlspecialchars($key??'', ENT_QUOTES, 'UTF-8');
 
 			if (is_array($value))
 			{
@@ -832,7 +832,7 @@ class Apache_Solr_Service
 						$fieldBoost = false;
 					}
 
-					$multivalue = htmlspecialchars($multivalue, ENT_NOQUOTES, 'UTF-8');
+					$multivalue = htmlspecialchars($multivalue??'', ENT_NOQUOTES, 'UTF-8');
 
 					$xml .= '>' . $multivalue . '</field>';
 				}
@@ -846,7 +846,7 @@ class Apache_Solr_Service
 					$xml .= ' boost="' . $fieldBoost . '"';
 				}
 
-				$value = htmlspecialchars($value, ENT_NOQUOTES, 'UTF-8');
+				$value = htmlspecialchars($value??'', ENT_NOQUOTES, 'UTF-8');
 
 				$xml .= '>' . $value . '</field>';
 			}
@@ -925,7 +925,7 @@ class Apache_Solr_Service
 		$committedValue = $fromCommitted ? 'true' : 'false';
 
 		//escape special xml characters
-		$id = htmlspecialchars($id, ENT_NOQUOTES, 'UTF-8');
+		$id = htmlspecialchars($id??'', ENT_NOQUOTES, 'UTF-8');
 
 		$rawPost = '<delete fromPending="' . $pendingValue . '" fromCommitted="' . $committedValue . '"><id>' . $id . '</id></delete>';
 
@@ -953,7 +953,7 @@ class Apache_Solr_Service
 		foreach ($ids as $id)
 		{
 			//escape special xml characters
-			$id = htmlspecialchars($id, ENT_NOQUOTES, 'UTF-8');
+			$id = htmlspecialchars($id??'', ENT_NOQUOTES, 'UTF-8');
 
 			$rawPost .= '<id>' . $id . '</id>';
 		}
@@ -980,7 +980,7 @@ class Apache_Solr_Service
 		$committedValue = $fromCommitted ? 'true' : 'false';
 
 		// escape special xml characters
-		$rawQuery = htmlspecialchars($rawQuery, ENT_NOQUOTES, 'UTF-8');
+		$rawQuery = htmlspecialchars($rawQuery??'', ENT_NOQUOTES, 'UTF-8');
 
 		$rawPost = '<delete fromPending="' . $pendingValue . '" fromCommitted="' . $committedValue . '"><query>' . $rawQuery . '</query></delete>';
 

--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ Also, feel free to search and ask questions on the google mailing list: [php-sol
 ## License
 
 Code is released under a 3-Clause BSD license, see [COPYING](https://github.com/PTCInc/solr-php-client/blob/master/COPYING) for full text.
+


### PR DESCRIPTION
`$multivalue` can be `NULL` which causes spam of https://php.watch/versions/8.1/internal-func-non-nullable-null-deprecation notices during reindex. Also null proofed other instances of `htmlspecialchars` to be safe